### PR TITLE
fix: run component test in nested folder

### DIFF
--- a/src/get-subfolder-name.js
+++ b/src/get-subfolder-name.js
@@ -1,0 +1,17 @@
+/**
+ * @param {string} path filepath
+ * @param {string} parentFolder parent folder
+ * @returns {string} subfolder path after given parent folder
+ */
+function getSubfolderName(path, parentFolder) {
+    const splitPath = path.split("/");
+    const parentFolderIndex = splitPath.findIndex((it) => it === parentFolder);
+
+    if (parentFolderIndex === -1) {
+        throw new Error(`Could not find "${parentFolder}" in path "${path}"`);
+    }
+
+    return splitPath.slice(parentFolderIndex + 1, -1).join("/");
+}
+
+module.exports = { getSubfolderName };

--- a/src/get-subfolder-name.spec.js
+++ b/src/get-subfolder-name.spec.js
@@ -1,0 +1,24 @@
+const { getSubfolderName } = require("./get-subfolder-name");
+
+it("should handle when parent folder is first folder", () => {
+    expect.assertions(1);
+    const subfolderName = getSubfolderName("src/foo/bar/baz/test.cy.ts", "src");
+    expect(subfolderName).toBe("foo/bar/baz");
+});
+
+it("should handle when parent folder is last folder", () => {
+    expect.assertions(1);
+    const subfolderName = getSubfolderName("foo/bar/baz/src/test.cy.ts", "src");
+    expect(subfolderName).toBe("");
+});
+
+it("should handle when parent folder is between first and last folder", () => {
+    expect.assertions(1);
+    const subfolderName = getSubfolderName("foo/bar/src/baz/test.cy.ts", "src");
+    expect(subfolderName).toBe("baz");
+});
+
+it("should throw when parent folder is not found", () => {
+    expect.assertions(1);
+    expect(() => getSubfolderName("foo/bar/baz/test.cy.ts", "src")).toThrow();
+});

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -3,6 +3,7 @@ const fsPromises = require("node:fs/promises");
 const path = require("path");
 
 const { compareImages } = require("./utils");
+const { getSubfolderName } = require("./get-subfolder-name");
 
 /** @type {string} */
 let CYPRESS_SCREENSHOT_DIR = "cypress/screenshots";
@@ -91,7 +92,7 @@ async function visualRegressionCopy(args) {
         if (parentFolder[0] === "src") {
             parentFolder = absolute.split("/").slice(-4, -1).join("/");
         } else {
-            parentFolder = parentFolder.join("/");
+            parentFolder = getSubfolderName(absolute, "src");
         }
         const checkFrom = path.join(parentFolder, from);
 


### PR DESCRIPTION
Previously a certain nested level was required below `src` folder.